### PR TITLE
Fix JSON syntax in 1030.json (FileDrive Labs)

### DIFF
--- a/Allocators/1030.json
+++ b/Allocators/1030.json
@@ -38,7 +38,7 @@
     "pathway_addresses": {
       "msig": "f2n2cvq3wi344zua7ofax4jygkcqb4lwbhdtofhmq",
       "signer": [
-        "f1vewqfhde62bjccdiy3qbjbhg37ldr4y7nm5wv6q"
+        "f1vewqfhde62bjccdiy3qbjbhg37ldr4y7nm5wv6q",
         "f1hhfjedejpwi44wffdqrs3xl6bnygzfjfj3tzpaq"
       ]
     }


### PR DESCRIPTION
Current JSON is invalid (missing comma) so update wasn't applied.

@galen-mcandrew @Filedrive-ops

Reported in https://github.com/fidlabs/allocator-tooling/issues/75