### PR TITLE
Correct and revert f2 1060.json

### DIFF
--- a/Allocators/1060.json
+++ b/Allocators/1060.json
@@ -1,6 +1,6 @@
 {
     "application_number": 1060,
-    "address": "f23q74wvk6zq2dfopfe4wbt2tal2fkwicexcqui5q",
+    "address": "f26btyj7einvdsg2n2sq34tcdvvspzk6yld6grftq",
     "name": "Max",
     "organization": "CoinSummer Labs",
     "location": "Hong Kong",
@@ -37,7 +37,7 @@
         "github_user": "maxvint"
     },
     "pathway_addresses": {
-        "msig": "f23q74wvk6zq2dfopfe4wbt2tal2fkwicexcqui5q",
+        "msig": "f26btyj7einvdsg2n2sq34tcdvvspzk6yld6grftq",
         "signer": [
             "f1bv4fwfmiuww25jhwqvtjsjofxu77iyhqac4j6qy"
         ]


### PR DESCRIPTION
Reverting the recorded f2 msig back to the address created by the governance team with this initial allocator application. This f2 address (ending inrftq) has the DataCap allowance. 

This f2 was edited to have a new signer, as requested by the allocator here: https://github.com/filecoin-project/Allocator-Registry/issues/163#issuecomment-2368852645