### PR TITLE
Revert f2 1065.json

### DIFF
--- a/Allocators/1065.json
+++ b/Allocators/1065.json
@@ -1,6 +1,6 @@
 {
     "application_number": 1065,
-    "address": "f2gelosrtlc7iciehlytdrz2dqsakgadtuclp4eli",
+    "address": "f2uib6cqjmos6ir4ajx4aqt4pbglrrsd7w6ubovki",
     "name": "Max",
     "organization": "MinerDAO",
     "location": "Hong Kong",
@@ -33,7 +33,7 @@
         "github_user": "maxvint"
     },
     "pathway_addresses": {
-        "msig": "f2gelosrtlc7iciehlytdrz2dqsakgadtuclp4eli",
+        "msig": "f2uib6cqjmos6ir4ajx4aqt4pbglrrsd7w6ubovki",
         "signer": [
             "f1bv4fwfmiuww25jhwqvtjsjofxu77iyhqac4j6qy"
         ]


### PR DESCRIPTION
Reverting the recorded f2 msig back to the address created by the governance team with this initial allocator application. This f2 address (ending bovki) has the DataCap allowance.

This f2 was edited to have a new signer, as requested by the allocator here: https://github.com/filecoin-project/Allocator-Registry/issues/163#issuecomment-2368852645