### PR TITLE
Change Faucet MetaAllocator address to f4 format

### DIFF
--- a/Allocators/77.json
+++ b/Allocators/77.json
@@ -1,6 +1,6 @@
 {
   "application_number": "76",
-  "address": "0x386f08f6E8E4647B871415EBFB858b1e377d9ab2",
+  "address": "f410fhbxqr5xi4rshxbyucxv7xbmldy3x3gvsjrcnply",
   "name": "Faucet MetaAllocator",
   "organization": "FIDL",
   "location": "Africa,Europe,Greater China Region,North America,Oceania,South America,Asia minus GCR",


### PR DESCRIPTION
All other JSONs use f4 addresses in the `address` field. Let's make it consistent. It breaks some external tooling.