### PR TITLE
fix(allocator): Correct invalid end date in data file

### DIFF
--- a/Allocators/recFIKHBHym4Ei4F8.json
+++ b/Allocators/recFIKHBHym4Ei4F8.json
@@ -83,7 +83,7 @@
     },
     {
       "started": "2025-08-12T01:00:00.000Z",
-      "ended": "2025-08-212T01:00:00.000Z",
+      "ended": "2025-08-21T01:00:00.000Z",
       "dc_allocated": "2025-08-22T01:00:00.000Z",
       "outcome": "THROTTLE",
       "datacap_amount": 5


### PR DESCRIPTION
This PR fixes the allocator file `recFIKHBHym4Ei4F8`, which contains an invalid `ended` ISO date: `2025-08-212T01:00:00.000Z`. The day portion has 3 digits; it should be 2.

This commit corrects the date to a valid ISO format: `2025-08-21T01:00:00.000Z`.

https://en.wikipedia.org/wiki/ISO_8601