### PR TITLE
fix(allocators): Normalize github_handles format

### DIFF
--- a/Allocators/rec6QbLJrCmTmkxUc.json
+++ b/Allocators/rec6QbLJrCmTmkxUc.json
@@ -26,7 +26,7 @@
       "smart_contract_allocator"
     ],
     "github_handles": [
-      "https://github.com/sxxfuture-official"
+      "sxxfuture-official"
     ],
     "allocation_bookkeeping": "https://github.com/sxxfuture-official/filplus-allocator-sxxfuture",
     "client_contract_address": "f410f4vrwdtgwulg3ni5u6zr24tyxysgjf74iunf6dei"

--- a/Allocators/recO07KvsZwYA4XiP.json
+++ b/Allocators/recO07KvsZwYA4XiP.json
@@ -25,7 +25,7 @@
       "smart_contract_allocator"
     ],
     "github_handles": [
-      "@Destore2023"
+      "Destore2023"
     ],
     "allocation_bookkeeping": "https://github.com/Destore2023/MetaPathways-Bookkeeping/issues",
     "client_contract_address": "f410fegrsvirv5rh3nnebtvehghrekspdvb4xlz556jy"


### PR DESCRIPTION
This PR fixes the `github_handles` field for some allocators that contained inconsistent formatting, such as full URLs or handles prefixed with '@'.

This commit cleans up the handles for `sxxfuture-official` and `Destore2023` to ensure they contain only the username, improving data consistency and preventing potential parsing errors.